### PR TITLE
fix: follow redirects in list_buckets httpx client

### DIFF
--- a/src/mcp_server_activitywatch/tools/list_buckets.py
+++ b/src/mcp_server_activitywatch/tools/list_buckets.py
@@ -42,7 +42,7 @@ async def list_buckets(
     try:
         api_base = ctx.lifespan_context["api_base"] if ctx else "http://localhost:5600/api/0"
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             response = await client.get(f"{api_base}/buckets", timeout=10.0)
             response.raise_for_status()
             buckets_data = response.json()


### PR DESCRIPTION
## Problem

`activitywatch-list-buckets` fails with a `308 PERMANENT REDIRECT` error because `httpx.AsyncClient` does not follow redirects by default.

ActivityWatch server redirects `GET /api/0/buckets` → `GET /api/0/buckets/`, which httpx silently fails on instead of following.

**Error seen:**
```
Failed to fetch buckets: Redirect response '308 PERMANENT REDIRECT' for url 'http://localhost:5600/api/0/buckets'
Redirect location: 'http://localhost:5600/api/0/buckets/'
```

## Fix

One-line change: add `follow_redirects=True` to the `httpx.AsyncClient` constructor in `list_buckets.py`.

## Testing

Verified locally against ActivityWatch v0.13.2 on Linux — `list-buckets` now returns all buckets correctly.